### PR TITLE
fix: handle divide by zero in calculate()

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,8 @@ def greet(name):
     return f"Hello, {name}"
 
 def calculate(a, b):
-    # TODO: this function crashes if b is 0
+    if b == 0:
+        raise ValueError("Cannot divide by zero: 'b' must be non-zero.")
     return a / b
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add a guard in `calculate()` that raises `ValueError` when `b == 0`, instead of crashing with an unhandled `ZeroDivisionError`.

Closes #1

## Test plan
- [x] `calculate(10, 2)` returns `5.0` (normal case still works)
- [x] `calculate(10, 0)` raises `ValueError` with descriptive message

🤖 Generated with [Claude Code](https://claude.com/claude-code)